### PR TITLE
Fix infinite `fetch_commands.sh` request loop

### DIFF
--- a/app/dashboard/advanced-settings/at-terminal/page.tsx
+++ b/app/dashboard/advanced-settings/at-terminal/page.tsx
@@ -107,7 +107,7 @@ const ATTerminalPage = () => {
     };
 
     fetchCommands();
-  }, [toast]);
+  }, []);
 
   // Load previous commands and history from localStorage on component mount
   useEffect(() => {


### PR DESCRIPTION
## Issue
`fetch_commands.sh` request is fired repeatedly, nonstop while the AT Terminal page is open (until my browser grinds to a halt)

## Build
SDXPINN stable, 1.0.1

## Fix
The effect does reference the `toast` hook, so having it as a dependency does feel valid - but in practice it doesn't make sense that this static data should be re-fetched if the toast UI changes. So removing the dependency feels reasonable to me.

For the cause: `useToast()` is creating and returning a new object each time it runs ([here](https://github.com/dr-dolomite/QuecManager-JS/blob/d3a07089864a8cee0c7eb234407e26245c9d73f5/hooks/use-toast.ts#L187C2-L191C4)) so you can't reference its return value directly in an effect dependency array.