### PR TITLE
Handle missing `phoneNumber` in home data

### DIFF
--- a/hooks/home-data.ts
+++ b/hooks/home-data.ts
@@ -58,7 +58,7 @@ const useHomeData = () => {
           phoneNumber:
             rawData[1].response
               .split("\n")[1]
-              .split(":")[1]
+              ?.split(":")[1]
               .split(",")[1]
               .replace(/"/g, "")
               .trim() || "Unknown",


### PR DESCRIPTION
My device isn't reporting the phone number, which breaks the rest of the page.

```
command: "AT+CNUM"
response: "AT+CNUM"
status: "success"
```