### PR TITLE
Fix IPv4 PDP type parameter

### DIFF
--- a/app/dashboard/cell-settings/basic-settings/page.tsx
+++ b/app/dashboard/cell-settings/basic-settings/page.tsx
@@ -228,7 +228,7 @@ const BasicSettings = () => {
   // Map PDP type values to display labels
   const getPDPTypeLabel = (value: string) => {
     const pdpTypes: Record<string, string> = {
-      "IPV4": "IPv4 Only",
+      "IP": "IPv4 Only",
       "IPV6": "IPv6 Only",
       "IPV4V6": "IPv4 and IPv6",
       "P2P": "P2P Protocol"
@@ -306,7 +306,7 @@ const BasicSettings = () => {
                     <SelectContent>
                       <SelectGroup>
                         <SelectLabel>PDP Type</SelectLabel>
-                        <SelectItem value="IPV4">IPv4 Only</SelectItem>
+                        <SelectItem value="IP">IPv4 Only</SelectItem>
                         <SelectItem value="IPV6">IPv6 Only</SelectItem>
                         <SelectItem value="IPV4V6">IPv4 and IPv6</SelectItem>
                         <SelectItem value="P2P">P2P Protocol</SelectItem>

--- a/components/pages/apn-profile-card.tsx
+++ b/components/pages/apn-profile-card.tsx
@@ -51,7 +51,7 @@ const INITIAL_FORM_STATE: APNProfileFormData = {
 };
 
 const PDP_TYPES = [
-  { value: "IPV4", label: "IPv4 Only" },
+  { value: "IP", label: "IPv4 Only" },
   { value: "IPV6", label: "IPv6 Only" },
   { value: "IPV4V6", label: "IPv4 and IPv6" },
   { value: "P2P", label: "P2P Protocol" },
@@ -260,7 +260,7 @@ const APNProfilesCard = () => {
             <SelectContent>
               <SelectGroup>
                 <SelectLabel>PDP Type</SelectLabel>
-                <SelectItem value="IPV4">IPv4 Only</SelectItem>
+                <SelectItem value="IP">IPv4 Only</SelectItem>
                 <SelectItem value="IPV6">IPv6 Only</SelectItem>
                 <SelectItem value="IPV4V6">IPv4 and IPv6</SelectItem>
                 <SelectItem value="P2P">P2P Protocol</SelectItem>
@@ -293,7 +293,7 @@ const APNProfilesCard = () => {
 
   const getPDPTypeLabel = (pdpType: string | undefined | null): string => {
     const pdpTypeMap: Record<string, string> = {
-      IPV4: "IPv4 Only",
+      IP: "IPv4 Only",
       IPV6: "IPv6 Only",
       IPV4V6: "IPv4 and IPv6",
       P2P: "P2P Protocol",


### PR DESCRIPTION
"IPV4" isn't a valid PDP type - it's just "IP" for v4.

```
<PDP_type> String type. Packet data protocol type.
"IP" IPv4. Internet protocol (see IETF STD 5)
"PPP" Point to Point Protocol (see IETF STD 51)
"IPV6" Internet Protocol, version 6 (see RFC 2460)
"IPV4V6" Virtual <PDP_type> introduced to handle dual IP stack UE capability. (See 3GPP TS24.301)
```

Ref: RG65xE&RG650V&RM550V&RM551E_Series_AT_Commands_Manual page 85

(note: this change is basically just a find and replace - I don't  have a development environment set up to test it - but it doesn't look like there are any other references)