### PR TITLE
Feature/refactor home data hook

### DIFF
--- a/components/home/band-card.tsx
+++ b/components/home/band-card.tsx
@@ -88,11 +88,15 @@ const BandCard = ({
           <p className="text-sm font-bold">
             {bandNumber.includes("NR5G") ? "NR-SNR" : "SINR"}
           </p>
+          {/* Adjusted the coloring for SINR's minVal on the high to 14 for LTE,  middle range to >= -2 /* }
+          {/* Even thirds spread puts LTE high range to 14, and mid range to -2 for both /*}
+          {/* NR5G range is -23 to 40 */}
+          {/* LTE range is -20 to 30 */}
           <Badge
             className={
-              parseInt(sinr) >= 20
+              parseInt(sinr) >= (bandNumber.includes("NR5G") ? 20 : 14)
                 ? "bg-emerald-500 hover:bg-emerald-800"
-                : parseInt(sinr) >= 0
+                : parseInt(sinr) >= -2
                 ? "bg-orange-500 hover:bg-orange-800"
                 : "bg-rose-500 hover:bg-rose-800"
             }

--- a/components/home/band-table.tsx
+++ b/components/home/band-table.tsx
@@ -172,11 +172,15 @@ const BandTable = ({ bands, isLoading }: BandTableProps) => {
 
                       <div className="flex justify-between w-full">
                         <p>SINR</p>
+                        {/* Adjusted the coloring for SINR's minVal on the high to 14 for LTE,  middle range to >= -2 /* }
+                        {/* Even thirds spread puts LTE high range to 14, and mid range to -2 for both /*}
+                        {/* NR5G range is -23 to 40 */}
+                        {/* LTE range is -20 to 30 */}
                         <Badge
                           className={
                             parseInt(band.sinr) >= 20
                               ? "bg-emerald-500 hover:bg-emerald-800"
-                              : parseInt(band.sinr) >= 0
+                              : parseInt(band.sinr) >= -2
                               ? "bg-orange-500 hover:bg-orange-800"
                               : "bg-rose-500 hover:bg-rose-800"
                           }

--- a/hooks/home-data.ts
+++ b/hooks/home-data.ts
@@ -143,107 +143,48 @@ const useHomeData = () => {
       // Process the raw data into the HomeData format
       const processedData: HomeData = {
         simCard: {
-          slot: parseField(rawData[0].response, 1, 1),
+          slot: parseField(rawData[0].response, 1, 1, 0),
           state: rawData[6].response.includes("READY") ? "Inserted" : "Not Inserted",
-          provider: parseField(rawData[2].response, 1, 2),
-          phoneNumber: parseField(rawData[1].response, 1, 1),
-          imsi: parseField(rawData[3].response, 1, 0),
-          iccid: parseField(rawData[4].response, 1, 1),
-          imei: parseField(rawData[5].response, 1, 0),
+          provider: parseField(rawData[2].response, 1, 1, 2),
+          phoneNumber: parseField(rawData[1].response, 1, 1, 1),
+          imsi: parseField(rawData[3].response, 1, 0, 0),
+          iccid: parseField(rawData[4].response, 1, 1, 1, "Unknown", " "),
+          imei: parseField(rawData[5].response, 1, 0, 0),
         },
         connection: {
-          apn: parseField(rawData[7]?.response, 1,2, parseField(rawData[12]?.response, 1,2)),
-          operatorState:
-            getOperatorState(rawData[8]?.response, rawData[16]?.response) ||
-            "Unknown",
-          functionalityState:
-            rawData[9].response.split("\n")[1]?.split(":")[1].trim() === "1"
-              ? "Enabled"
-              : "Disabled",
+          apn: parseField(rawData[7]?.response, 1, 1, 2, parseField(rawData[12]?.response, 1, 1, 2)),
+          operatorState: getOperatorState(rawData[8]?.response, rawData[16]?.response) || "Unknown",
+          functionalityState: parseField(rawData[9]?.response, 1, 1, 0) === "1" ? "Enabled" : "Disabled",
           networkType: getNetworkType(rawData[13].response) || "No Signal",
-          modemTemperature:
-            getModemTemperature(rawData[11].response) || "Unknown",
-          accessTechnology:
-            getAccessTechnology(rawData[2].response) || "Unknown",
+          modemTemperature: getModemTemperature(rawData[11].response) || "Unknown",
+          accessTechnology: getAccessTechnology(rawData[2].response) || "Unknown",
         },
         dataTransmission: {
-          carrierAggregation:
-            rawData[13].response.match(/"LTE BAND \d+"|"NR5G BAND \d+"/g)
-              ?.length > 1
-              ? "Multi"
-              : "Inactive",
-          bandwidth:
-            getBandwidth(
-              rawData[13].response,
-              getNetworkType(rawData[13].response)
-            ) || "Unknown",
+          carrierAggregation: rawData[13].response.match(/"LTE BAND \d+"|"NR5G BAND \d+"/g) ?.length > 1 ? "Multi" : "Inactive",
+          bandwidth: getBandwidth(rawData[13].response, getNetworkType(rawData[13].response)) || "Unknown",
           connectedBands: getConnectedBands(rawData[13].response) || "Unknown",
           signalStrength: getSignalStrength(rawData[14].response) || "Unknown",
           mimoLayers: getMimoLayers(rawData[14].response) || "Unknown",
         },
         cellularInfo: {
-          cellId:
-            getCellID(
-              rawData[10].response,
-              getNetworkType(rawData[13].response)
-            ) || "Unknown",
-          trackingAreaCode:
-            getTAC(
-              rawData[10].response,
-              getNetworkType(rawData[13].response)
-            ) || "Unknown",
-          physicalCellId: getPhysicalCellIDs(
-            rawData[13].response,
-            getNetworkType(rawData[13].response)
-          ),
+          cellId: getCellID(rawData[10].response, getNetworkType(rawData[13].response)) || "Unknown",
+          trackingAreaCode: getTAC(rawData[10].response, getNetworkType(rawData[13].response)) || "Unknown",
+          physicalCellId: getPhysicalCellIDs(rawData[13].response, getNetworkType(rawData[13].response)),
           earfcn: getEARFCN(rawData[13].response),
-          mcc:
-            getMCC(
-              rawData[10].response,
-              getNetworkType(rawData[13].response)
-            ) || "Unknown",
-          mnc:
-            getMNC(
-              rawData[10].response,
-              getNetworkType(rawData[13].response)
-            ) || "Unknown",
+          mcc: getMCC(rawData[10].response, getNetworkType(rawData[13].response)) || "Unknown",
+          mnc: getMNC(rawData[10].response, getNetworkType(rawData[13].response)) || "Unknown",
           signalQuality: getSignalQuality(rawData[19].response) || "Unknown",
         },
         currentBands: {
           // id is length of bandNumber
-          id: Array.from(
-            {
-              length:
-                getCurrentBandsBandNumber(rawData[13].response)?.length ?? 0,
-            },
-            (_, i) => i + 1
-          ) || [1],
-          bandNumber: getCurrentBandsBandNumber(rawData[13].response) || [
-            "Unknown",
-          ],
+          id: Array.from({ length: getCurrentBandsBandNumber(rawData[13].response)?.length ?? 0, }, (_, i) => i + 1) || [1],
+          bandNumber: getCurrentBandsBandNumber(rawData[13].response) || ["Unknown",],
           earfcn: getCurrentBandsEARFCN(rawData[13].response),
-          bandwidth: getCurrentBandsBandwidth(rawData[13].response) || [
-            "Unknown",
-          ],
-          pci: getCurrentBandsPCI(
-            rawData[13].response,
-            getNetworkType(rawData[13].response)
-          ) || ["Unknown"],
-          rsrp: getCurrentBandsRSRP(
-            rawData[13].response,
-            getNetworkType(rawData[13].response),
-            rawData[10].response
-          ),
-          rsrq: getCurrentBandsRSRQ(
-            rawData[13].response,
-            getNetworkType(rawData[13].response),
-            rawData[10].response
-          ) || ["Unknown"],
-          sinr: getCurrentBandsSINR(
-            rawData[13].response,
-            getNetworkType(rawData[13].response),
-            rawData[10].response
-          ) || ["Unknown"],
+          bandwidth: getCurrentBandsBandwidth(rawData[13].response) || ["Unknown",],
+          pci: getCurrentBandsPCI(rawData[13].response, getNetworkType(rawData[13].response)) || ["Unknown"],
+          rsrp: getCurrentBandsRSRP(rawData[13].response, getNetworkType(rawData[13].response), rawData[10].response),
+          rsrq: getCurrentBandsRSRQ(rawData[13].response, getNetworkType(rawData[13].response), rawData[10].response) || ["Unknown"],
+          sinr: getCurrentBandsSINR(rawData[13].response, getNetworkType(rawData[13].response), rawData[10].response) || ["Unknown"],
         },
         networkAddressing: {
           publicIPv4: publicIPResponse.ok
@@ -511,8 +452,8 @@ const useHomeData = () => {
           })(),
         },
         timeAdvance: {
-          lteTimeAdvance: parseField(rawData[21]?.response, 1, 2),
-          nrTimeAdvance: parseField(rawData[22]?.response, 1, 2),
+          lteTimeAdvance: parseField(rawData[21]?.response, 1, 1, 2),
+          nrTimeAdvance: parseField(rawData[22]?.response, 1, 1, 2),
         },
       };
 
@@ -575,13 +516,14 @@ const useHomeData = () => {
 const parseField = (
   response: string,
   lineIndex: number,
+  firstField: number,
   fieldIndex: number,
   defaultValue = "Unknown",
   delimiter = ","
 ) => {
   try {
     return (
-      response.split("\n")[lineIndex]?.split(":")[1]?.split(delimiter)[
+      response.split("\n")[lineIndex]?.split(":")[firstField]?.split(delimiter)[
         fieldIndex
       ]?.replace(/"/g, "")
         .trim() || defaultValue
@@ -590,13 +532,13 @@ const parseField = (
     return defaultValue;
   }
 };
-const getProviderName = (response: string) => parseField(response, 1, 2);
-const getAccessTechnology = (response: string) => parseField(response, 1, 3);
+const getProviderName = (response: string) => parseField(response, 1, 1, 2);
+const getAccessTechnology = (response: string) => parseField(response, 1, 1, 3);
 
 
 const getOperatorState = (lteResponse: string, nr5gResponse: string) => {
   const state =
-    Number(parseField(lteResponse,1,1)) || Number(parseField(nr5gResponse,1,1))
+    Number(parseField(lteResponse,1,1,1)) || Number(parseField(nr5gResponse,1,1,1))
   switch (state) {
     case 1:
       return "Registered";

--- a/hooks/home-data.ts
+++ b/hooks/home-data.ts
@@ -1563,6 +1563,10 @@ const getMimoLayers = (response: string) => {
   }
 };
 
+const filterField = (data: string, needle: string, delimiter: string, returnIndex:integer) => {
+  return data.split(delimiter).filter(x => x.includes(needle))[returnIndex];
+};
+
 // Add this helper function in your file (outside the React component)
 const formatDottedIPv6 = (dottedIPv6: string): string => {
   try {

--- a/hooks/home-data.ts
+++ b/hooks/home-data.ts
@@ -389,7 +389,7 @@ const useHomeData = () => {
 
               if (!matchingLine) return "-";
 
-              // Step 3: Extract primary DNS (second to last field)
+              // Step 3: Extract secondary DNS (last field)
               const parts = matchingLine.split(",");
               if (parts.length < 2) return "-";
 
@@ -1142,7 +1142,7 @@ const getCurrentBandsRSRP = (
     // Existing NR5G-SA handling - no changes needed
     const pccRSRP = servingCell.split("\n").find((l) => l.includes("NR5G-SA"));
     const pccValue = pccRSRP
-      ? pccRSRP?.split(":")[1]?.split(",")[9]
+      ? pccRSRP?.split(":")[1]?.split(",")[12]
       : "Unknown";
 
     // Get all SCC RSRP values
@@ -1246,7 +1246,7 @@ const getCurrentBandsRSRQ = (
     // Existing NR5G-SA handling - no changes needed
     const pccRSRQ = servingCell.split("\n").find((l) => l.includes("NR5G-SA"));
     const pccValue = pccRSRQ
-      ? pccRSRQ?.split(":")[1]?.split(",")[10]
+      ? pccRSRQ?.split(":")[1]?.split(",")[13]
       : "Unknown";
 
     // Get all SCC RSRQ values
@@ -1342,6 +1342,7 @@ const getCurrentBandsSINR = (
 ) => {
   // Loop through the response and extract the SINR
   if (networkType === "LTE") {
+    // if LTE mode the value may need to be calcuted to get actual SINR, Y = (1/5) × X × 10 - 20 (X is the <SINR> from QENG for only the PCC band)
     const sinrs = response.split("\n").filter((l) => l.includes("BAND"));
     return sinrs.map((l) => l?.split(":")[1]?.split(",")[9]);
   }
@@ -1352,16 +1353,16 @@ const getCurrentBandsSINR = (
     let pccValue = "Unknown";
 
     if (pccSINR) {
-      const rawSINR = pccSINR?.split(":")[1]?.split(",")[11];
+      const rawSINR = pccSINR?.split(":")[1]?.split(",")[14];
       // If value is -32768, use "-" instead of "Unknown"
       if (rawSINR === "-32768") {
         pccValue = "-";
       } else {
-        // Apply the SNR conversion formula: SNR = value / 100
+        // PCC SNR value from QENG is already calculated in the correct format, no need to value/100
         const sinrValue = parseInt(rawSINR);
         if (!isNaN(sinrValue)) {
-          // Return a whole number only and round up when necessary
-          pccValue = Math.round(sinrValue / 100).toString();
+          // PCC SINR value from QENG is already in correctly calcuated SINR db format
+          pccValue = sinrValue.toString();
         } else {
           pccValue = rawSINR || "Unknown";
         }

--- a/hooks/home-data.ts
+++ b/hooks/home-data.ts
@@ -1472,47 +1472,32 @@ const getCurrentBandsSINR = (
 const getMimoLayers = (response: string) => {
   // Constants for invalid signal values
   const INVALID_VALUES = [-32768, -140];
-  const lteRSRPExists = response.split("\n").find((l) => l.includes("LTE"));
-  const nr5gRSRPExists = response.split("\n").find((l) => l.includes("NR5G"));
-
-  // Get the RSRP values for LTE and NR5G
-  let lteRSRPArr: any[] = [];
-  let nr5gRSRPArr: any[] = [];
-
-  // If RSRP LTE exists
-  if (lteRSRPExists) {
-    lteRSRPArr = lteRSRPExists
+  
+  // Helper function to extract and filter RSRP values
+  const extractRSRP = (line: string | undefined): number[] =>
+    line
       ?.split(":")[1]
       ?.split(",")
       .slice(0, 4)
-      .map((v) => parseInt(v.trim()));
+      .map((v) => parseInt(v.trim()))
+      .filter((v) => !INVALID_VALUES.includes(v)) || [];
+
+  // Extract RSRP values for LTE and NR5G
+  const lteRSRPArr = extractRSRP(response.split("\n").find((l) => l.includes("LTE")));
+  const nr5gRSRPArr = extractRSRP(response.split("\n").find((l) => l.includes("NR5G")));
+
+
+  // Determine MIMO layers
+  if (lteRSRPArr.length && nr5gRSRPArr.length) {
+    return `LTE ${lteRSRPArr.length} / NR ${nr5gRSRPArr.length}`;
   }
-
-  // If RSRP NR5G exists
-  if (nr5gRSRPExists) {
-    nr5gRSRPArr = nr5gRSRPExists
-      ?.split(":")[1]
-      ?.split(",")
-      .slice(0, 4)
-      .map((v) => parseInt(v.trim()));
-  }
-
-  // Filter out invalid values
-  lteRSRPArr = lteRSRPArr.filter((v) => !INVALID_VALUES.includes(v));
-  nr5gRSRPArr = nr5gRSRPArr.filter((v) => !INVALID_VALUES.includes(v));
-
-  // Get the length of the arrays and return as MIMO layers
   if (lteRSRPArr.length) {
-    if (nr5gRSRPArr.length) {
-      return `LTE ${lteRSRPArr.length.toString()} / NR ${nr5gRSRPArr.length.toString()}`;
-    } else {
-      return `LTE ${lteRSRPArr.length.toString()}`;
-    }
-  } else if (nr5gRSRPArr.length) {
-    return `NR ${nr5gRSRPArr.length.toString()}`;
-  } else {
-    return "Unknown";
+    return `LTE ${lteRSRPArr.length}`;
   }
+  if (nr5gRSRPArr.length) {
+    return `NR ${nr5gRSRPArr.length}`;
+  }
+  return "Unknown";
 };
 
 // Add this helper function in your file (outside the React component)

--- a/hooks/home-data.ts
+++ b/hooks/home-data.ts
@@ -459,7 +459,6 @@ const useHomeData = () => {
 
       setData(processedData);
       setRetryCount(0);
-      // setData(processedData);
       setError(null);
       console.log("Processed home data:", processedData);
     } catch (error) {

--- a/hooks/home-data.ts
+++ b/hooks/home-data.ts
@@ -394,7 +394,7 @@ const useHomeData = () => {
               if (parts.length < 2) return "-";
 
               // Primary DNS is the second to last element
-              const dnsAddress = parts[parts.length - 2]
+              const dnsAddress = parts[parts.length - 1]
                 .replace(/"/g, "")
                 .trim();
 
@@ -423,6 +423,7 @@ const useHomeData = () => {
           // Raw DNS addresses without formatting
           rawCarrierPrimaryDNS: (() => {
             try {
+              // [15] is the WWAN QMAP response, [20] is the CGCONTRDP response
               if (!rawData[15]?.response || !rawData[20]?.response) return "-";
 
               // Step 1: Get profile ID from QMAP="WWAN" response

--- a/hooks/home-data.ts
+++ b/hooks/home-data.ts
@@ -693,8 +693,6 @@ const getSignalStrength = (response: string) => {
       .map((v) => parseInt(v.trim()))
       .filter((v) => !invalidRSRPvalues.includes(v));
   }
-  console.log('rsrpNrArr', rsrpNrArr);
-
 
   // Calculate the average RSRP values average percentage where -75 is best and -125 is worst
   if (rsrpLteArr.length) {


### PR DESCRIPTION
Primary Function: Code Reduction of home-data.ts

Secondary Functions: 
- Resolve the NR5G-SA PCC RSRP value incorrectly showing the ARFCN value, possibly also affects the SCC bands, still validating this.
- Resolve the Secondary DNS value showing the Primary DNS value

This was tested with LTE only, NR5G-NSA, and NR5G-SA on T-Mobile with latest RM551E-GL firmware.

Unable to test the Time Advance data. My results are 0 for both LTE and 5G.