### PR TITLE
Second Refactor for home-data.ts

### DIFF
--- a/components/home/cellular-info.tsx
+++ b/components/home/cellular-info.tsx
@@ -9,6 +9,12 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import { Badge } from "@/components/ui/badge";
 import { HomeData } from "@/types/types";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface CellularInformationProps {
   data: HomeData | null;
@@ -33,7 +39,18 @@ const CellularInformation = ({ data, isLoading }: CellularInformationProps) => {
         </div>
 
         <div className="flex flex-row justify-between text-md">
-          <p>TAC</p>
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger>
+              TAC
+              </TooltipTrigger>
+              <TooltipContent>
+                <div className="grid grid-cols-1 gap-1">
+                  <span className="font-medium">Region / Tracking Area Code</span>
+                </div>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
           {isLoading ? (
             <Skeleton className="h-4 w-[80px]" />
           ) : (

--- a/hooks/cell-settings-data.ts
+++ b/hooks/cell-settings-data.ts
@@ -122,8 +122,8 @@ const useCellSettingsData = () => {
             return "-";
           }
         })(),
-        lteAMBR: getLTEAMBRValue(rawData[9].response),
-        nr5gAMBR: getNR5GAMBRValue(rawData[10].response),
+        lteAMBR: getLTEAMBRValue(rawData[9]?.response),
+        nr5gAMBR: getNR5GAMBRValue(rawData[10]?.response),
       };
 
       console.log("Processed cell settings data:", processedData);

--- a/hooks/home-data.ts
+++ b/hooks/home-data.ts
@@ -167,8 +167,8 @@ const useHomeData = () => {
           mimoLayers: getMimoLayers(rawData[14].response) || "Unknown",
         },
         cellularInfo: {
-          cellId: getCellID(rawData[10].response, getNetworkType(rawData[13].response)) || "Unknown",
-          trackingAreaCode: getTAC(rawData[10].response, getNetworkType(rawData[13].response)) || "Unknown",
+          cellId: extractValueByNetworkType(rawData[10]?.response, getNetworkType(rawData[13]?.response), { "NR5G-SA": 1, "NR5G-NSA": 2, "LTE": 1 }, { "NR5G-SA": 6, "NR5G-NSA": 4, "LTE": 6 }),
+          trackingAreaCode: extractValueByNetworkType(rawData[10]?.response, getNetworkType(rawData[13]?.response), { "NR5G-SA": 1, "NR5G-NSA": 2, "LTE": 1 }, { "NR5G-SA": 8, "NR5G-NSA": 10, "LTE": 12 }),
           physicalCellId: getPhysicalCellIDs(rawData[13].response, getNetworkType(rawData[13].response)),
           earfcn: getEARFCN(rawData[13].response),
           mcc: getMCC(rawData[10].response, getNetworkType(rawData[13].response)) || "Unknown",
@@ -700,32 +700,13 @@ const getSignalStrength = (response: string): string => {
   return "Unknown%";
 };
 
-const getCellID = (response: string, networkType: string) => {
-  if (networkType === "NR5G-SA" || networkType === "LTE") {
-    return response.split("\n")[1]?.split(":")[1]?.split(",")[6].trim();
-  }
-
-  if (networkType === "NR5G-NSA") {
-    return response.split("\n")[2]?.split(":")[1]?.split(",")[4].trim();
-  }
-
-  return "Unknown";
-};
-
-const getTAC = (response: string, networkType: string) => {
-  if (networkType === "NR5G-SA") {
-    return response.split("\n")[1]?.split(":")[1]?.split(",")[8].trim();
-  }
-
-  if (networkType === "NR5G-NSA") {
-    return response.split("\n")[2]?.split(":")[1]?.split(",")[10].trim();
-  }
-
-  if (networkType === "LTE") {
-    return response.split("\n")[1]?.split(":")[1]?.split(",")[12].trim();
-  }
-
-  return "Unknown";
+// Function to parse the TAC and CellID from the response and return the values from Hex to Decimal format based on the lineIndex and fieldIndex of the respective Index Maps
+const extractValueByNetworkType = (response: string, networkType: string, lineIndexMap: Record<string, number>, fieldIndexMap: Record<string, number>): string => {
+  const lineIndex = lineIndexMap[networkType];
+  const fieldIndex = fieldIndexMap[networkType];
+  return lineIndex !== undefined && fieldIndex !== undefined
+    ? parseInt(parseField(response, lineIndex, 1, fieldIndex), 16).toString().toUpperCase()
+    : "Unknown";
 };
 
 const getPhysicalCellIDs = (response: string, networkType: string): string => {

--- a/hooks/home-data.ts
+++ b/hooks/home-data.ts
@@ -1319,12 +1319,11 @@ const getCurrentBandsSINR = (
   return ["Unknown"];
 };
 
-const getMimoLayers = (response: string) => {
-  // Constants for invalid signal values
+const getMimoLayers = (response: string): string => {
   const INVALID_VALUES = [-32768, -140];
-  
+
   // Helper function to extract and filter RSRP values
-  const extractRSRP = (line: string | undefined): number[] =>
+  const extractRSRP = (line?: string): number[] =>
     line
       ?.split(":")[1]
       ?.split(",")
@@ -1333,20 +1332,13 @@ const getMimoLayers = (response: string) => {
       .filter((v) => !INVALID_VALUES.includes(v)) || [];
 
   // Extract RSRP values for LTE and NR5G
-  const lteRSRPArr = extractRSRP(response.split("\n").find((l) => l.includes("LTE")));
-  const nr5gRSRPArr = extractRSRP(response.split("\n").find((l) => l.includes("NR5G")));
-
+  const lteRSRPCount = extractRSRP(response.split("\n").find((l) => l.includes("LTE"))).length;
+  const nr5gRSRPCount = extractRSRP(response.split("\n").find((l) => l.includes("NR5G"))).length;
 
   // Determine MIMO layers
-  if (lteRSRPArr.length && nr5gRSRPArr.length) {
-    return `LTE ${lteRSRPArr.length} / NR ${nr5gRSRPArr.length}`;
-  }
-  if (lteRSRPArr.length) {
-    return `LTE ${lteRSRPArr.length}`;
-  }
-  if (nr5gRSRPArr.length) {
-    return `NR ${nr5gRSRPArr.length}`;
-  }
+  if (lteRSRPCount && nr5gRSRPCount) return `LTE ${lteRSRPCount} / NR ${nr5gRSRPCount}`;
+  if (lteRSRPCount) return `LTE ${lteRSRPCount}`;
+  if (nr5gRSRPCount) return `NR ${nr5gRSRPCount}`;
   return "Unknown";
 };
 

--- a/hooks/home-data.ts
+++ b/hooks/home-data.ts
@@ -555,13 +555,10 @@ const getOperatorState = (lteResponse: string, nr5gResponse: string) => {
 };
 
 const getNetworkType = (response: string) => {
-  const bands = response.match(/"LTE BAND \d+"|"NR5G BAND \d+"/g);
+  const bands = response.match(/"LTE BAND \d+"|"NR5G BAND \d+"/g) || [];
   const hasLTE = bands?.some((band) => band.includes("LTE"));
   const hasNR5G = bands?.some((band) => band.includes("NR5G"));
-  if (hasLTE && hasNR5G) return "NR5G-NSA";
-  if (hasLTE) return "LTE";
-  if (hasNR5G) return "NR5G-SA";
-  return "No Signal";
+  return hasLTE && hasNR5G ? "NR5G-NSA" : hasLTE ? "LTE" : hasNR5G ? "NR5G-SA" : "No Signal";
 };
 
 const getModemTemperature = (response: string) => {

--- a/hooks/home-data.ts
+++ b/hooks/home-data.ts
@@ -769,26 +769,11 @@ const getEARFCN = (response: string) => {
   return "Unknown";
 };
 
-const getMCC = (response: string, networkType: string) => {
-  if (networkType === "LTE" || networkType === "NR5G-SA") {
-    return response.split("\n")[1]?.split(":")[1]?.split(",")[4].trim();
-  }
-
-  if (networkType === "NR5G-NSA") {
-    return response.split("\n")[2]?.split(":")[1]?.split(",")[2].trim();
-  }
-
-  return "Unknown";
-};
-
-const getMNC = (response: string, networkType: string) => {
-  if (networkType === "LTE" || networkType === "NR5G-SA") {
-    return response.split("\n")[1]?.split(":")[1]?.split(",")[5].trim();
-  }
-
-  if (networkType === "NR5G-NSA") {
-    return response.split("\n")[2]?.split(":")[1]?.split(",")[3].trim();
-  }
+// Function to get the MNC or MCC based on the network type and field index map
+const getNetworkCode = (response: string, networkType: string, fieldIndexMap: Record<string, number>): string => {
+  const lineIndex = networkType === "NR5G-NSA" ? 2 : 1;
+  const fieldIndex = fieldIndexMap[networkType];
+  return parseField(response, lineIndex, 1, fieldIndex) || "Unknown";
 };
 
 const getSignalQuality = (response: string): string => {

--- a/hooks/home-data.ts
+++ b/hooks/home-data.ts
@@ -921,56 +921,28 @@ const getCurrentBandsBandwidth = (response: string) => {
   }
 };
 
-const getCurrentBandsPCI = (response: string, networkType: string) => {
+const getCurrentBandsPCI = (response: string, networkType: string): string[] => {
+  const extractPCI = (lines: string[], fieldIndex: number): string[] =>
+    lines.map((line) => line.split(":")[1]?.split(",")[fieldIndex]?.trim() || "Unknown");
+
+  const lines = response.split("\n");
+
   if (networkType === "NR5G-SA") {
-    const lines = response.split("\n");
-    const result = [];
-
-    // Handle PCC - keep your existing code since it works
-    const pccLine = lines.find((l) => l.includes("PCC"));
-    if (pccLine) {
-      const pccPCI = pccLine.split(":")[1].split(",")[4].trim();
-      result.push(pccPCI || "Unknown");
-    }
-
-    // Handle SCCs - fix the index for NR5G-SA mode
-    const sccLines = lines.filter((l) => l.includes("SCC"));
-    for (const sccLine of sccLines) {
-      const parts = sccLine.split(":")[1].split(",");
-      // For NR5G-SA mode, SCC PCI is at index 5, not 4
-      result.push(parts.length > 5 ? parts[5].trim() : "Unknown");
-    }
-
-    return result.length > 0 ? result : ["Unknown"];
+    const pccPCI = extractPCI(lines.filter((l) => l.includes("PCC")), 4)[0];
+    const sccPCIs = extractPCI(lines.filter((l) => l.includes("SCC")), 5);
+    return [pccPCI, ...sccPCIs].filter((pci) => pci !== "Unknown");
   }
 
-  // Keep your existing code for LTE and NR5G-NSA
-  else if (networkType === "LTE") {
-    let PCCpci = response.split("\n").find((l) => l.includes("PCC"));
-    PCCpci = PCCpci ? PCCpci?.split(":")[1]?.split(",")[5].trim() : "Unknown";
-    const SCCpcis = response
-      .split("\n")
-      .filter((l) => l.includes("SCC") && l.includes("LTE BAND"));
-    if (!SCCpcis.length) {
-      return [PCCpci];
-    } else {
-      const pcis = SCCpcis.map(
-        (l) => l?.split(":")[1]?.split(",")[5] || "Unknown"
-      );
-      return [PCCpci, ...pcis];
-    }
-  } else if (networkType === "NR5G-NSA") {
-    const pcisLte = response.split("\n").filter((l) => l.includes("LTE BAND"));
-    const pcisNr5g = response
-      .split("\n")
-      .filter((l) => l.includes("NR5G BAND"));
-    const pcisLteValues = pcisLte.map(
-      (l) => l?.split(":")[1]?.split(",")[5] || "Unknown"
-    );
-    const pcisNr5gValues = pcisNr5g.map(
-      (l) => l?.split(":")[1]?.split(",")[4] || "Unknown"
-    );
-    return [...pcisLteValues, ...pcisNr5gValues];
+  if (networkType === "LTE") {
+    const pccPCI = extractPCI(lines.filter((l) => l.includes("PCC")), 5)[0];
+    const sccPCIs = extractPCI(lines.filter((l) => l.includes("SCC") && l.includes("LTE BAND")), 5);
+    return [pccPCI, ...sccPCIs].filter((pci) => pci !== "Unknown");
+  }
+
+  if (networkType === "NR5G-NSA") {
+    const ltePCIs = extractPCI(lines.filter((l) => l.includes("LTE BAND")), 5);
+    const nr5gPCIs = extractPCI(lines.filter((l) => l.includes("NR5G BAND")), 4);
+    return [...ltePCIs, ...nr5gPCIs].filter((pci) => pci !== "Unknown");
   }
 
   return ["Unknown"];

--- a/hooks/home-data.ts
+++ b/hooks/home-data.ts
@@ -531,9 +531,8 @@ const parseField = (
     return defaultValue;
   }
 };
-const getProviderName = (response: string) => parseField(response, 1, 1, 2);
-const getAccessTechnology = (response: string) => parseField(response, 1, 1, 3);
 
+const getAccessTechnology = (response: string) => parseField(response, 1, 1, 3);
 
 const getOperatorState = (lteResponse: string, nr5gResponse: string): "Unknown" | "Registered" | "Searching" | "Denied" | "Roaming" | "Not Registered" => {
   const state =
@@ -558,9 +557,7 @@ const getNetworkType = (response: string) => {
 const getModemTemperature = (response: string) => {
   const temps = ["cpuss-0", "cpuss-1", "cpuss-2", "cpuss-3"].map((cpu) => {
     const line = response.split("\n").find((l) => l.includes(cpu));
-    return parseInt(
-      line!?.split(":")[1]?.split(",")[1].replace(/"/g, "").trim()
-    );
+    return parseInt(line!?.split(":")[1]?.split(",")[1].replace(/"/g, "").trim());
   });
   const avgTemp = temps.reduce((acc, t) => acc + t, 0) / temps.length;
   return `${Math.round(avgTemp)}°C`;

--- a/hooks/home-data.ts
+++ b/hooks/home-data.ts
@@ -171,8 +171,8 @@ const useHomeData = () => {
           trackingAreaCode: extractValueByNetworkType(rawData[10]?.response, getNetworkType(rawData[13]?.response), { "NR5G-SA": 1, "NR5G-NSA": 2, "LTE": 1 }, { "NR5G-SA": 8, "NR5G-NSA": 10, "LTE": 12 }),
           physicalCellId: getPhysicalCellIDs(rawData[13].response, getNetworkType(rawData[13].response)),
           earfcn: getEARFCN(rawData[13].response),
-          mcc: getMCC(rawData[10].response, getNetworkType(rawData[13].response)) || "Unknown",
-          mnc: getMNC(rawData[10].response, getNetworkType(rawData[13].response)) || "Unknown",
+          mcc: getNetworkCode(rawData[10]?.response, getNetworkType(rawData[13]?.response), { "NR5G-NSA": 2, "LTE": 4, "NR5G-SA": 4 }),
+          mnc: getNetworkCode(rawData[10]?.response, getNetworkType(rawData[13]?.response), { "NR5G-NSA": 3, "LTE": 5, "NR5G-SA": 5 }),
           signalQuality: getSignalQuality(rawData[19].response) || "Unknown",
         },
         currentBands: {

--- a/hooks/home-data.ts
+++ b/hooks/home-data.ts
@@ -893,32 +893,19 @@ const getCurrentBandsEARFCN = (response: string) => {
   }
 };
 
-const getCurrentBandsBandwidth = (response: string) => {
-  // Loop through the response and extract the bandwidth
-  const bandwidthsLte = response
-    .split("\n")
-    .filter((l) => l.includes("LTE BAND"));
-  const bandwidthsNr5g = response
-    .split("\n")
-    .filter((l) => l.includes("NR5G BAND"));
+const getCurrentBandsBandwidth = (response: string): string[] => {
+  const extractBandwidths = (type: string, map: Record<string, string>) =>
+    response
+      .split("\n")
+      .filter((line) => line.includes(type))
+      .map((line) => map[line.split(":")[1]?.split(",")[2]] || "Unknown");
 
-  // Convert the bandwidths to their respective values
-  const parsedBandwidthsLte = bandwidthsLte.map(
-    (l) => BANDWIDTH_MAP[l?.split(":")[1]?.split(",")[2]]
-  );
-  const parsedBandwidthsNr5g = bandwidthsNr5g.map(
-    (l) => NR_BANDWIDTH_MAP[l?.split(":")[1]?.split(",")[2]]
-  );
+  const bandwidthsLte = extractBandwidths("LTE BAND", BANDWIDTH_MAP);
+  const bandwidthsNr5g = extractBandwidths("NR5G BAND", NR_BANDWIDTH_MAP);
 
-  if (parsedBandwidthsLte.length && parsedBandwidthsNr5g.length) {
-    return [...parsedBandwidthsLte, ...parsedBandwidthsNr5g];
-  } else if (parsedBandwidthsLte.length) {
-    return parsedBandwidthsLte;
-  } else if (parsedBandwidthsNr5g.length) {
-    return parsedBandwidthsNr5g;
-  } else {
-    return ["Unknown"];
-  }
+  return [...bandwidthsLte, ...bandwidthsNr5g].length
+    ? [...bandwidthsLte, ...bandwidthsNr5g]
+    : ["Unknown"];
 };
 
 const getCurrentBandsPCI = (response: string, networkType: string): string[] => {

--- a/hooks/home-data.ts
+++ b/hooks/home-data.ts
@@ -783,27 +783,15 @@ const getSignalQuality = (response: string): string => {
     : "Unknown%";
 };
 
-// Get current band information
-const getCurrentBandsBandNumber = (response: string) => {
-  // Loop through the response and extract the band number
-  const bandsLte = response.split("\n").filter((l) => l.includes("LTE BAND"));
-  const bandsNr5g = response.split("\n").filter((l) => l.includes("NR5G BAND"));
+const getCurrentBandsBandNumber = (response: string): string[] => {
+  const extractBands = (lines: string[]): string[] =>
+    lines.map((line) => line.split(":")[1]?.split(",")[3]?.replace(/"/g, "") || "Unknown");
 
-  if (bandsLte.length && bandsNr5g.length) {
-    return [...bandsLte, ...bandsNr5g].map((l) =>
-      l?.split(":")[1]?.split(",")[3].replace(/"/g, "")
-    );
-  } else if (bandsLte.length) {
-    return bandsLte.map((l) =>
-      l?.split(":")[1]?.split(",")[3].replace(/"/g, "")
-    );
-  } else if (bandsNr5g.length) {
-    return bandsNr5g.map((l) =>
-      l?.split(":")[1]?.split(",")[3].replace(/"/g, "")
-    );
-  } else {
-    return ["Unknown"];
-  }
+  const bandsLte = extractBands(response.split("\n").filter((line) => line.includes("LTE BAND")));
+  const bandsNr5g = extractBands(response.split("\n").filter((line) => line.includes("NR5G BAND")));
+
+  const allBands = [...bandsLte, ...bandsNr5g];
+  return allBands.length ? allBands : ["Unknown"];
 };
 
 const getCurrentBandsEARFCN = (response: string): string[] => {

--- a/hooks/home-data.ts
+++ b/hooks/home-data.ts
@@ -373,7 +373,6 @@ const getModemTemperature = (response: string) => {
   return `${Math.round(avgTemp)}°C`;
 };
 
-
 const getSignalStrength = (response: string): string => {
   const INVALID_RSRP_VALUES = [-140, -37625, -32768];
   // Helper function to extract and filter RSRP values
@@ -409,7 +408,6 @@ const extractValueByNetworkType = (response: string, networkType: string, lineIn
     ? parseField(response, lineIndex, 1, fieldIndex).toUpperCase()
     : "Unknown";
 };
-
 
 // Function to get the MNC or MCC based on the network type and field index map
 const getNetworkCode = (response: string, networkType: string, fieldIndexMap: Record<string, number>): string => {
@@ -532,7 +530,6 @@ const getCurrentBandsRSRP = (
   const pccRSRP = extractRSRP(lines.filter((l)=> l.includes("PCC")))[0];
   const sccRSRPs = extractRSRP(lines.filter((l) => l.includes("SCC")));
   return [pccRSRP, ...sccRSRPs].filter((pci) => pci !== "Unknown");
-
 };
 
 const getCurrentBandsRSRQ = (
@@ -569,7 +566,6 @@ const getCurrentBandsSINR = (
   response: string,
   networkType: string,
 ): string[] => {
-
   const getSINRFromParts = (parts: string[] | undefined): string => {
     if (!parts) return "Unknown";
     const pciIndex: 7 | 9 | 11 = (() => {

--- a/hooks/home-data.ts
+++ b/hooks/home-data.ts
@@ -744,44 +744,71 @@ const getMimoLayers = (response: string): string => {
 // Add this helper function in your file (outside the React component)
 const formatDottedIPv6 = (dottedIPv6: string): string => {
   try {
+    // Split by dots
     const parts = dottedIPv6.split(".");
-    if (parts.length < 8) return dottedIPv6; // Return as-is if not a valid dotted IPv6
+
+    // Only process if it looks like a dotted IPv6
+    if (parts.length < 8) return dottedIPv6;
 
     // Convert each decimal to 2-digit hex
-    const hexParts = parts.map((part) => parseInt(part, 10).toString(16).padStart(2, "0"));
+    const hexParts = parts.map((part) => {
+      const num = parseInt(part, 10);
+      if (isNaN(num)) return "00";
+      return num.toString(16).padStart(2, "0");
+    });
 
     // Group into 8 blocks of 2 bytes each
-    const ipv6Blocks = Array.from({ length: 8 }, (_, i) =>
-      hexParts[i * 2] + (hexParts[i * 2 + 1] || "00")
-    );
-
-    // Remove leading zeros from each block
-    const cleanedBlocks = ipv6Blocks.map((block) => block.replace(/^0+/, "") || "0");
-
-    // Find the longest run of consecutive zeros for compression
-    const zeroRun = cleanedBlocks.reduce(
-      (acc, block, i) => {
-        if (block === "0") {
-          acc.current.push(i);
-          if (acc.current.length > acc.longest.length) acc.longest = [...acc.current];
-        } else {
-          acc.current = [];
-        }
-        return acc;
-      },
-      { current: [] as number[], longest: [] as number[] }
-    ).longest;
-
-    // Apply zero compression if applicable
-    if (zeroRun.length >= 2) {
-      return cleanedBlocks
-        .map((block, i) => (i === zeroRun[0] ? "" : zeroRun.includes(i) ? null : block))
-        .filter((block) => block !== null)
-        .join(":")
-        .replace(/::+/g, "::");
+    const ipv6Blocks = [];
+    for (let i = 0; i < hexParts.length; i += 2) {
+      if (i + 1 < hexParts.length) {
+        ipv6Blocks.push(hexParts[i] + hexParts[i + 1]);
+      } else {
+        ipv6Blocks.push(hexParts[i] + "00");
+      }
     }
 
-    return cleanedBlocks.join(":"); // Return without compression if no zero run
+    // Remove leading zeros from each block
+    const cleanedBlocks = ipv6Blocks.map(
+      (block) => block.replace(/^0+/, "") || "0"
+    );
+
+    // Find longest run of zeros for compression
+    let longestZeros: string | any[] = [];
+    let currentZeros = [];
+
+    for (let i = 0; i < cleanedBlocks.length; i++) {
+      if (cleanedBlocks[i] === "0") {
+        currentZeros.push(i);
+      } else if (currentZeros.length > 0) {
+        if (currentZeros.length > longestZeros.length) {
+          longestZeros = [...currentZeros];
+        }
+        currentZeros = [];
+      }
+    }
+
+    // Check final run of zeros
+    if (currentZeros.length > longestZeros.length) {
+      longestZeros = [...currentZeros];
+    }
+
+    // Apply zero compression if we have at least 2 consecutive zeros
+    if (longestZeros.length >= 2) {
+      const result = [];
+      for (let i = 0; i < cleanedBlocks.length; i++) {
+        if (i === longestZeros[0]) {
+          result.push(""); // Start of compressed section
+          i = longestZeros[longestZeros.length - 1]; // Skip to end of zeros
+        } else {
+          result.push(cleanedBlocks[i]);
+        }
+      }
+
+      return result.join(":").replace(/::+/g, "::");
+    }
+
+    // If no compression, just join the blocks
+    return cleanedBlocks.join(":");
   } catch (err) {
     console.error("Error formatting IPv6:", err);
     return dottedIPv6;

--- a/hooks/home-data.ts
+++ b/hooks/home-data.ts
@@ -873,24 +873,17 @@ const getCurrentBandsBandNumber = (response: string) => {
   }
 };
 
-const getCurrentBandsEARFCN = (response: string) => {
-  // Loop through the response and extract the EARFCN
-  const earfcnsLte = response.split("\n").filter((l) => l.includes("LTE BAND"));
-  const earfcnsNr5g = response
-    .split("\n")
-    .filter((l) => l.includes("NR5G BAND"));
+const getCurrentBandsEARFCN = (response: string): string[] => {
+  const extractEARFCNs = (type: string) =>
+    response
+      .split("\n")
+      .filter((line) => line.includes(type))
+      .map((line) => line.split(":")[1]?.split(",")[1]?.trim() || "Unknown");
 
-  if (earfcnsLte.length && earfcnsNr5g.length) {
-    return [...earfcnsLte, ...earfcnsNr5g].map(
-      (l) => l?.split(":")[1]?.split(",")[1]
-    );
-  } else if (earfcnsLte.length) {
-    return earfcnsLte.map((l) => l?.split(":")[1]?.split(",")[1]);
-  } else if (earfcnsNr5g.length) {
-    return earfcnsNr5g.map((l) => l?.split(":")[1]?.split(",")[1]);
-  } else {
-    return ["Unknown"];
-  }
+  const earfcnsLte = extractEARFCNs("LTE BAND");
+  const earfcnsNr5g = extractEARFCNs("NR5G BAND");
+
+  return [...earfcnsLte, ...earfcnsNr5g].length ? [...earfcnsLte, ...earfcnsNr5g] : ["Unknown"];
 };
 
 const getCurrentBandsBandwidth = (response: string): string[] => {

--- a/hooks/home-data.ts
+++ b/hooks/home-data.ts
@@ -537,21 +537,15 @@ const getAccessTechnology = (response: string) => parseField(response, 1, 1, 3);
 
 const getOperatorState = (lteResponse: string, nr5gResponse: string) => {
   const state =
-    Number(parseField(lteResponse,1,1,1)) || Number(parseField(nr5gResponse,1,1,1))
-  switch (state) {
-    case 1:
-      return "Registered";
-    case 2:
-      return "Searching";
-    case 3:
-      return "Denied";
-    case 4:
-      return "Unknown";
-    case 5:
-      return "Roaming";
-    default:
-      return "Not Registered";
-  }
+  Number(parseField(lteResponse,1,1,1)) || Number(parseField(nr5gResponse,1,1,1))
+  const stateMap: Record<number, string> = {
+    1: "Registered",
+    2: "Searching",
+    3: "Denied",
+    4: "Unknown",
+    5: "Roaming",
+  };
+  return stateMap[state] || "Not Registered";
 };
 
 const getNetworkType = (response: string) => {

--- a/hooks/home-data.ts
+++ b/hooks/home-data.ts
@@ -535,10 +535,10 @@ const getProviderName = (response: string) => parseField(response, 1, 1, 2);
 const getAccessTechnology = (response: string) => parseField(response, 1, 1, 3);
 
 
-const getOperatorState = (lteResponse: string, nr5gResponse: string) => {
+const getOperatorState = (lteResponse: string, nr5gResponse: string): "Unknown" | "Registered" | "Searching" | "Denied" | "Roaming" | "Not Registered" => {
   const state =
-  Number(parseField(lteResponse,1,1,1)) || Number(parseField(nr5gResponse,1,1,1))
-  const stateMap: Record<number, string> = {
+    Number(parseField(lteResponse, 1, 1, 1)) || Number(parseField(nr5gResponse, 1, 1, 1));
+  const stateMap: Record<number, "Unknown" | "Registered" | "Searching" | "Denied" | "Roaming" | "Not Registered"> = {
     1: "Registered",
     2: "Searching",
     3: "Denied",

--- a/types/types.ts
+++ b/types/types.ts
@@ -37,6 +37,8 @@ export interface CellularInfoData {
   cellId?: string;
   trackingAreaCode?: string;
   physicalCellId?: string;
+  cellIdRaw: string, 
+  trackingAreaCodeRaw: string,
   earfcn?: string;
   mcc?: string;
   mnc?: string;


### PR DESCRIPTION
Major overall, cleanup, and reduction of code reuse with home-data.ts methods. 

Includes Bug Fix for LTE/NSA SCC bands PCI value not parsing correctly

- Added HexToDecimal for TAC and CellID
- Added tooltip to TAC field for user clarity
- Added cellIdRaw and TAC Raw fields to types.
