### PR TITLE
[BUG FIX] Cell Scanner NR5G Data Parsing

### DIFF
--- a/app/dashboard/experimental/cell-scanner/page.tsx
+++ b/app/dashboard/experimental/cell-scanner/page.tsx
@@ -302,9 +302,9 @@ const CellScannerPage = () => {
           } as LTECellInfo;
         } else if (type === "NR5G") {
           const [
+            scs,
             cellId,
             tac,
-            scs,
             carrierBandwidth,
             band,
             offsetToPointA,
@@ -782,10 +782,10 @@ const CellScannerPage = () => {
                             <TableCell>
                               {cell.type === "LTE"
                                 ? (cell as LTECellInfo).bandwidthMHz
-                                : "-"}
+                                : (cell as NR5GCellInfo).carrierBandwidth + "MHz"}
                             </TableCell>
-                            <TableCell>{cell.cellId}</TableCell>
-                            <TableCell>{cell.tac}</TableCell>
+                            <TableCell>{parseInt(cell.cellId,16)}</TableCell>
+                            <TableCell>{parseInt(cell.tac,16)}</TableCell>
                             <TableCell>
                               <TooltipProvider>
                                 <Tooltip>

--- a/components/pages/frequency-info-card.tsx
+++ b/components/pages/frequency-info-card.tsx
@@ -40,7 +40,7 @@ interface NR5GCellInfo extends BaseCellInfo {
   carrierBandwidth: number;
   offsetToPointA: number;
   ssbSubcarrierOffset: number;
-  ssbScs: number;
+  ssbScs: number | "-";
 }
 
 type CellInfo = LTECellInfo | NR5GCellInfo;
@@ -418,9 +418,9 @@ const FrequencyInfoCard = ({
           } as LTECellInfo;
         } else if (type === "NR5G") {
           const [
+            scs,
             cellId,
             tac,
-            scs,
             carrierBandwidth,
             band,
             offsetToPointA,
@@ -438,7 +438,7 @@ const FrequencyInfoCard = ({
             band: parseInt(band),
             offsetToPointA: parseInt(offsetToPointA),
             ssbSubcarrierOffset: parseInt(ssbSubcarrierOffset),
-            ssbScs: parseInt(ssbScs),
+            ssbScs: ssbScs,
           } as NR5GCellInfo;
         }
 


### PR DESCRIPTION
Fixed parsing out put for NR5G parsing of QSCAN for CellID, TAC, SCS values throughout the cell scanner page