### PR TITLE
Heartbeat API Double Call Fix

### DIFF
--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -3,10 +3,11 @@ import Link from "next/link";
 import { useAuth } from "@/hooks/auth";
 import { ProtectedRoute } from "@/components/hoc/protected-route";
 import * as React from "react";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { RadioTower, User2Icon, Menu, Power } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import heartbeat from "@/hooks/heartbeat";
 
 import {
   atCommandSender,
@@ -56,10 +57,18 @@ interface IpResponse {
 const DashboardLayout = ({ children }: DashboardLayoutProps) => {
   const currentPathName = usePathname();
   const { logout } = useAuth();
+
   const { setTheme } = useTheme();
   const [isRebooting, setIsRebooting] = useState(false);
   const [isReconnecting, setIsReconnecting] = useState(false);
   const toast = useToast();
+
+  const { isServerAlive } = heartbeat();
+  useEffect(() => {
+    if (!isServerAlive) {
+      logout();
+    }
+  }, [isServerAlive, logout]);
 
   // Handler for rebooting the device
   const handleReboot = async () => {

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useAuth } from "@/hooks/auth";
 
 import Image from "next/image";
@@ -9,12 +9,20 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useToast } from "@/hooks/use-toast";
 import GithubButtonToast from "@/components/github-button";
+import heartbeat from "@/hooks/heartbeat";
 
 const LoginPage = () => {
   const { toast } = useToast();
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
-  const { login } = useAuth();
+  const { login, logout } = useAuth();
+
+  const { isServerAlive } = heartbeat();
+  useEffect(() => {
+    if (!isServerAlive) {
+      logout();
+    }
+  }, [isServerAlive, logout]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/components/pages/chart-preview.tsx
+++ b/components/pages/chart-preview.tsx
@@ -18,6 +18,9 @@ import { ModeToggle } from "@/components/dark-mode-toggle";
 import { calculateSignalPercentage } from "@/utils/signalMetrics";
 import { ArrowRightIcon } from "@radix-ui/react-icons";
 
+import { useAuth } from "@/hooks/auth";
+import heartbeat from "@/hooks/heartbeat";
+
 interface ModemResponse {
   response: string;
 }
@@ -57,8 +60,12 @@ export default function ChartPreviewSignal() {
   });
   const [initialLoading, setInitialLoading] = useState(true);
   const previousData = useRef<SignalData | null>(null);
-
+  const { logout } = useAuth();
+  const { isServerAlive } = heartbeat();
   useEffect(() => {
+    if (!isServerAlive) {
+      logout();
+    }
     const fetchStats = async () => {
       try {
         const response = await fetch("/cgi-bin/quecmanager/at_cmd/fetch_data.sh?set=5");
@@ -125,7 +132,7 @@ export default function ChartPreviewSignal() {
     fetchStats();
     const intervalId = setInterval(fetchStats, 2000);
     return () => clearInterval(intervalId);
-  }, [initialLoading]);
+  }, [initialLoading, isServerAlive, logout]);
 
   const chartData: ChartDataItem[] = [
     {

--- a/hooks/auth.ts
+++ b/hooks/auth.ts
@@ -52,53 +52,53 @@ interface SessionData {
 
 export function useAuth() {
   const [isAuthenticated, setIsAuthenticated] = useState<boolean>(false);
-  const [isServerAlive, setIsServerAlive] = useState<boolean>(true);
+  // const [isServerAlive, setIsServerAlive] = useState<boolean>(true);
   const router = useRouter();
 
   useEffect(() => {
     checkAuth();
 
-    // Start heartbeat check
-    const heartbeatInterval = setInterval(
-      checkServerStatus,
-      HEARTBEAT_INTERVAL
-    );
+    // // Start heartbeat check
+    // const heartbeatInterval = setInterval(
+    //   checkServerStatus,
+    //   HEARTBEAT_INTERVAL
+    // );
 
-    return () => {
-      clearInterval(heartbeatInterval);
-    };
+    // return () => {
+    //   clearInterval(heartbeatInterval);
+    // };
   }, []);
 
   // New function to check server status
-  async function checkServerStatus() {
-    try {
-      const response = await fetch("/cgi-bin/quecmanager/heartbeat.sh", {
-        method: "GET",
-        headers: {
-          "Cache-Control": "no-cache",
-        },
-      });
+  // async function checkServerStatus() {
+  //   try {
+  //     const response = await fetch("/cgi-bin/quecmanager/heartbeat.sh", {
+  //       method: "GET",
+  //       headers: {
+  //         "Cache-Control": "no-cache",
+  //       },
+  //     });
 
-      if (!response.ok) {
-        handleServerDown();
-        return;
-      }
+  //     if (!response.ok) {
+  //       handleServerDown();
+  //       return;
+  //     }
 
-      const result = await response.json();
-      if (!result.alive) {
-        handleServerDown();
-      } else {
-        setIsServerAlive(true);
-      }
-    } catch (error) {
-      handleServerDown();
-    }
-  }
+  //     const result = await response.json();
+  //     if (!result.alive) {
+  //       handleServerDown();
+  //     } else {
+  //       setIsServerAlive(true);
+  //     }
+  //   } catch (error) {
+  //     handleServerDown();
+  //   }
+  // }
 
-  function handleServerDown() {
-    setIsServerAlive(false);
-    logout();
-  }
+  // function handleServerDown() {
+  //   setIsServerAlive(false);
+  //   logout();
+  // }
 
   // Your existing functions
   function generateAuthToken(length = 32) {
@@ -190,5 +190,6 @@ export function useAuth() {
     }
   }
 
-  return { isAuthenticated, isServerAlive, login, logout, checkAuth };
+  // return { isAuthenticated, isServerAlive, login, logout, checkAuth };
+  return { isAuthenticated, login, logout, checkAuth };
 }

--- a/hooks/heartbeat.ts
+++ b/hooks/heartbeat.ts
@@ -1,0 +1,88 @@
+/**
+ * Custom hook that fetches and processes cellular modem data for the home dashboard.
+ * This hook handles data fetching, processing, error handling, and automatic refresh at regular intervals.
+ *
+ * The hook fetches data from the API endpoint `/cgi-bin/quecmanager/at_cmd/fetch_data.sh?set=1`
+ * and transforms the raw response into a structured {@link HomeData} format with information about:
+ * - SIM card details (slot, state, provider, etc.)
+ * - Connection information (APN, network type, temperature, etc.)
+ * - Data transmission metrics (carrier aggregation, bandwidth, signal strength)
+ * - Cellular information (cell ID, tracking area code, signal quality)
+ * - Current bands information (band numbers, EARFCN, PCI, signal metrics)
+ *
+ * @returns An object containing:
+ * - `data` - The processed cellular modem information, or null if not yet loaded
+ * - `isLoading` - Boolean indicating if data is currently being fetched
+ * - `error` - Any error that occurred during data fetching, or null if no error
+ * - `refresh` - Function to manually trigger a data refresh
+ *
+ * @example
+ * ```tsx
+ * const { data, isLoading, error, refresh } = useHomeData();
+ *
+ * if (isLoading) return <LoadingSpinner />;
+ * if (error) return <ErrorMessage error={error} />;
+ * return <HomeDisplay data={data} onRefresh={refresh} />;
+ * ```
+ */
+
+import { useState, useEffect } from "react";
+import { useAuth } from "@/hooks/auth";
+
+
+const heartbeat = () => {
+  const [isServerAlive, setIsServerAlive] = useState<boolean>(true);
+  const { logout } = useAuth(); // Assuming you have a logout function in your auth hook
+  const HEARTBEAT_INTERVAL = 5 * 1000; // Check server every 5 seconds
+  
+  useEffect(() => {
+
+    // Start heartbeat check
+    const heartbeatInterval = setInterval(
+      checkServerStatus,
+      HEARTBEAT_INTERVAL
+    );
+
+    return () => {
+      clearInterval(heartbeatInterval);
+    };
+  }, []);
+
+
+
+  // Helper functions for data processing
+  // New function to check server status
+  async function checkServerStatus() {
+    try {
+      const response = await fetch("/cgi-bin/quecmanager/heartbeat.sh", {
+        method: "GET",
+        headers: {
+          "Cache-Control": "no-cache",
+        },
+      });
+
+      if (!response.ok) {
+        handleServerDown();
+        return;
+      }
+
+      const result = await response.json();
+      if (!result.alive) {
+        handleServerDown();
+      } else {
+        setIsServerAlive(true);
+      }
+    } catch (error) {
+      handleServerDown();
+    }
+  }
+
+  function handleServerDown() {
+    setIsServerAlive(false);
+    logout();
+  }
+
+  return { isServerAlive };
+};
+
+export default heartbeat;


### PR DESCRIPTION
Restructured where the call for heartbeat.sh was occurring to remove the double call that was caused by the import and use of `useAuth` by both protected-route and layout components.

Segregated the heartbeat logic into it's own hook/ file easier management of the data call and parsing.