### PR TITLE
Dynamically allow loading and showing of Speedtest 'Module' on Home Dashboard

### DIFF
--- a/app/dashboard/home/page.tsx
+++ b/app/dashboard/home/page.tsx
@@ -74,7 +74,9 @@ const HomePage = () => {
     bytesReceived,
     refresh: refreshTrafficStats,
   } = useTrafficStats();
-
+  const capabilties = sessionStorage.getItem("modemCapabilities");
+  const capabilities = capabilties ? JSON.parse(capabilties) : null;
+  console.log('capabilities', capabilities);
   const sendChangeSimSlot = async () => {
     try {
       // Get the current SIM slot through AT+QUIMSLOT? command
@@ -380,7 +382,7 @@ const HomePage = () => {
               networkType={homeData?.connection?.networkType}
             />
             <MemoryCard />
-            <SpeedtestStream />
+            { capabilities?.speedtest && <SpeedtestStream />}
             <PingCard />
           </div>
         </div>

--- a/components/pages/chart-preview.tsx
+++ b/components/pages/chart-preview.tsx
@@ -59,6 +59,20 @@ export default function ChartPreviewSignal() {
   const previousData = useRef<SignalData | null>(null);
 
   useEffect(() => {
+    const fetchCapabilities = async () => {
+      try {
+        const response = await fetch("/cgi-bin/quecmanager/get-capabilities.sh");
+        const data: ModemResponse[] = await response.json();
+        sessionStorage.setItem("modemCapabilities", JSON.stringify(data));
+        return JSON.stringify(data);
+      } catch (error) {
+        console.error("Error fetching capabilities:", error);
+      }
+    };
+    fetchCapabilities();
+  }, []);
+
+  useEffect(() => {
     const fetchStats = async () => {
       try {
         const response = await fetch("/cgi-bin/quecmanager/at_cmd/fetch_data.sh?set=5");

--- a/scripts/cgi-bin/quecmanager/get-capabilities.sh
+++ b/scripts/cgi-bin/quecmanager/get-capabilities.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+SPEEDTEST=false
+FIRMWARE_VERSION=$(sms_tool at -t 3 'AT+QGMR' | sed -n '2p' | tr -d '\r')
+MODEM_TYPE=$(sms_tool at -t 3 'AT+CGMM' | sed -n '2p' | tr -d '\r')
+MODEM_MANUFACTURER=$(sms_tool at -t 3 'AT+CGMI' | sed -n '2p' | tr -d '\r')
+
+if [ command -v speedtest >/dev/null 2>&1 ]; then
+    SPEEDTEST=true
+fi
+
+RESPONSE="Content-Type: application/json\n"
+RESPONSE="${RESPONSE}Cache-Control: no-cache, no-store, must-revalidate\n"
+RESPONSE="${RESPONSE}Pragma: no-cache\n"
+RESPONSE="${RESPONSE}Expires: 0\n\n"
+RESPONSE="${RESPONSE}{\n"
+RESPONSE="${RESPONSE}  \"speedtest\": ${SPEEDTEST},\n"
+RESPONSE="${RESPONSE}  \"firmware\": \"${FIRMWARE_VERSION}\",\n"
+RESPONSE="${RESPONSE}  \"modem\": \"${MODEM_TYPE}\",\n"
+RESPONSE="${RESPONSE}  \"manufacturer\": \"${MODEM_MANUFACTURER}\"\n"
+RESPONSE="${RESPONSE}}\n"
+
+echo -e "${RESPONSE}"


### PR DESCRIPTION
Added:
- scripts/cgi-bin/quecmanager/get-capabilties.sh to allow as a way to return "statically" available capabilities and or device information
Updated:
- components/pages/chart-preview.tsx to call the new get-capabilities.sh and store into sessionStorage for use on dashboard
- app/dashboard/home/page.tsx to conditionally show/allow speedtest component