### PR TITLE
[BUG FIX] Update the AT-Client_Queue AT Terminal Error Response on invalid/timedout auth tokens

### DIFF
--- a/app/dashboard/advanced-settings/at-terminal/page.tsx
+++ b/app/dashboard/advanced-settings/at-terminal/page.tsx
@@ -340,7 +340,7 @@ const ATTerminalPage = () => {
         response: data?.response?.raw_output || "No output",
         timestamp: data.command.timestamp,
         status: data?.response?.status,
-        duration: data.response.duration_ms,
+        duration: data?.response?.duration_ms,
         commandId: data.command.id,
       };
 

--- a/app/dashboard/advanced-settings/at-terminal/page.tsx
+++ b/app/dashboard/advanced-settings/at-terminal/page.tsx
@@ -258,15 +258,15 @@ const ATTerminalPage = () => {
 
             // Show toast for errors
             if (
-              data.response.status === "error" ||
-              data.response.status === "timeout"
+              data?.response?.status === "error" ||
+              data?.response?.status === "timeout"
             ) {
               toast({
                 title: `Command ${
-                  data.response.status === "timeout" ? "Timeout" : "Error"
+                  data?.response?.status === "timeout" ? "Timeout" : "Error"
                 }`,
                 description:
-                  data.response.raw_output ||
+                  data?.response?.raw_output ||
                   `Command execution ${data.response.status}`,
                 variant: "destructive",
               });
@@ -274,7 +274,7 @@ const ATTerminalPage = () => {
           } catch (error) {
             const errorMessage =
               error instanceof Error
-                ? error.message
+                ? error?.message
                 : "An unknown error occurred";
             setOutput(`> ${previousCommand}\nError: ${errorMessage}`);
 
@@ -329,15 +329,15 @@ const ATTerminalPage = () => {
 
       // Format output
       let outputText = `> ${command}\n`;
-      if (data.response.raw_output) {
-        outputText += data.response.raw_output;
+      if (data?.response?.raw_output) {
+        outputText += data?.response?.raw_output;
       }
       setOutput(outputText);
 
       // Create new history item
       const newHistoryItem: CommandHistoryItem = {
         command: command,
-        response: data.response.raw_output || "No output",
+        response: data?.response?.raw_output || "No output",
         timestamp: data.command.timestamp,
         status: data.response.status,
         duration: data.response.duration_ms,
@@ -357,16 +357,16 @@ const ATTerminalPage = () => {
 
       // Show toast for errors
       if (
-        data.response.status === "error" ||
-        data.response.status === "timeout"
+        data?.response?.status === "error" ||
+        data?.response?.status === "timeout"
       ) {
         toast({
           title: `Command ${
-            data.response.status === "timeout" ? "Timeout" : "Error"
+            data?.response?.status === "timeout" ? "Timeout" : "Error"
           }`,
           description:
-            data.response.raw_output ||
-            `Command execution ${data.response.status}`,
+            data?.response?.raw_output ||
+            `Command execution ${data?.response?.status}`,
           variant: "destructive",
         });
       }

--- a/app/dashboard/advanced-settings/at-terminal/page.tsx
+++ b/app/dashboard/advanced-settings/at-terminal/page.tsx
@@ -339,7 +339,7 @@ const ATTerminalPage = () => {
         command: command,
         response: data?.response?.raw_output || "No output",
         timestamp: data.command.timestamp,
-        status: data.response.status,
+        status: data?.response?.status,
         duration: data.response.duration_ms,
         commandId: data.command.id,
       };

--- a/app/dashboard/advanced-settings/at-terminal/page.tsx
+++ b/app/dashboard/advanced-settings/at-terminal/page.tsx
@@ -267,7 +267,7 @@ const ATTerminalPage = () => {
                 }`,
                 description:
                   data?.response?.raw_output ||
-                  `Command execution ${data.response.status}`,
+                  `Command execution ${data?.response?.status}`,
                 variant: "destructive",
               });
             }

--- a/scripts/cgi-bin/quecmanager/at_cmd/at_queue_client.sh
+++ b/scripts/cgi-bin/quecmanager/at_cmd/at_queue_client.sh
@@ -193,7 +193,8 @@ if [ "${SCRIPT_NAME}" != "" ]; then
     fi
 
     if [ -z "$TOKEN" ] || "${TOKEN}" = "" || [ $(grep "${TOKEN}" "${AUTH_FILE}" | wc -l) -eq 0 ]; then
-        output_json "{\"error\":\"Not Authorized\"}" "0"
+        output_json "{\"response\": { \"status\": \"error\", \"raw_output\": \"Not Authorized\" }, \"command\": {\"timestamp\": \"$(date +%Y%m%d'T'%H%M%S)\"}, \"error\":\"Not Authorized\"}" "0"
+
         exit 1
     fi
 
@@ -205,7 +206,7 @@ if [ "${SCRIPT_NAME}" != "" ]; then
     MAX_AGE=$((2 * 3600)) # 2 hours in seconds
 
     if [ -z "$TOKEN_TIME" ] || [ $((NOW_TIME - TOKEN_TIME)) -gt $MAX_AGE ]; then
-        output_json "{\"error\":\"Token expired\"}" "0"
+        output_json "{ \"response\": { \"status\": \"error\", \"raw_output\": \"Token expired. Reauthenticate to get new token.\" }, \"command\": {\"timestamp\": \"$(date +%Y%m%d'T'%H%M%S)\"}, \"error\":\"Token expired\"}" "0"
         # Cleanup/Remove token from file
         sed -i -e "s/.*${TOKEN}.*//g" /tmp/auth_success 2>/dev/null
         exit 1


### PR DESCRIPTION
Non-Breaking UI Update

Updated the json object response for Invalid or Expired Auth Tokens.
Update the code stucture to not throw a generic error message on invalid expected data object for the Error modal.