### PR TITLE
[BUG FIX] "Home" Page Chart Preview Recursive fetch_data call fix

### DIFF
--- a/components/pages/chart-preview.tsx
+++ b/components/pages/chart-preview.tsx
@@ -129,7 +129,6 @@ export default function ChartPreviewSignal() {
       }
     };
 
-    fetchStats();
     const intervalId = setInterval(fetchStats, 2000);
     return () => clearInterval(intervalId);
   }, [initialLoading, isServerAlive, logout]);


### PR DESCRIPTION
Fixed the cgi-bin fetch_data call that apeared to not abide by the 2 second wait before fetching data again.

The fetchStats method was calling itself before putting the 2 second wait to call itself again ultimately causing a tree of sub child processes getting called to fetch_data. When run for an extended period of time this would crash the /dev/smd11 socat-at-bridge data bus and ultimately cause sms_tool to lose chain of custody in memory space to the socat-at-bridge