### PR TITLE
Bug/fix no sim detected error when sms tool crashes

### DIFF
--- a/app/dashboard/home/page.tsx
+++ b/app/dashboard/home/page.tsx
@@ -221,7 +221,7 @@ const HomePage = () => {
               <div className="flex flex-row items-center gap-6 justify-between w-full">
                   <h2 className="text-md font-bold">Modem Processing Error</h2>
                   <p className="text-sm font-bold">
-                    SMS_Tool failed to acquire token. Likely 'Bus Error'. Attempt to logout and log back in.
+                    SMS_Tool failed to acquire token. Likely 'Bus Error'. The system will attempt to recover automatically. If the issue persists, please logout and log back in.
                   </p>
               </div>
             </Card>

--- a/app/dashboard/home/page.tsx
+++ b/app/dashboard/home/page.tsx
@@ -15,6 +15,13 @@ import PingCard from "@/components/home/ping-card";
 
 import { Button } from "@/components/ui/button";
 import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
   Dialog,
   DialogContent,
   DialogDescription,
@@ -208,6 +215,18 @@ const HomePage = () => {
   return (
     <div className="grid xl:gap-y-10 gap-y-8 gap-4">
       <div className="grid gap-4">
+        { homeData?.simCard?.state?.toLowerCase().includes("failed") && (
+            <div className="grid lg:grid-cols-1 grid-cols-1 grid-flow-row gap-4">
+            <Card className="p-4 bg-red-500">
+              <div className="flex flex-row items-center gap-6 justify-between w-full">
+                  <h2 className="text-md font-bold">Modem Processing Error</h2>
+                  <p className="text-sm font-bold">
+                    SMS_Tool failed to acquire token. Likely 'Bus Error'. Attempt to logout and log back in.
+                  </p>
+              </div>
+            </Card>
+          </div>
+        )}
         <div className="flex flex-row justify-between items-center">
           <div className="flex flex-row gap-2 items-center">
             <h1 className="xl:text-3xl text-base font-bold">

--- a/app/dashboard/home/page.tsx
+++ b/app/dashboard/home/page.tsx
@@ -207,6 +207,13 @@ const HomePage = () => {
   }, [homeData]);
 
   useEffect(() => {
+    if (homeData?.simCard?.state?.toLowerCase().includes("failed")) {
+      toast({
+        title: "SMS_Tool failed to acquire token",
+        description: "The system will attempt to recover automatically. If this issue persists, please logout and log back in or restart the device.",
+        variant: "destructive",
+      });
+    }
     if (!isLoading && homeData?.simCard.state === "Not Inserted") {
       setNoSimDialogOpen(true);
     }
@@ -215,18 +222,6 @@ const HomePage = () => {
   return (
     <div className="grid xl:gap-y-10 gap-y-8 gap-4">
       <div className="grid gap-4">
-        { homeData?.simCard?.state?.toLowerCase().includes("failed") && (
-            <div className="grid lg:grid-cols-1 grid-cols-1 grid-flow-row gap-4">
-            <Card className="p-4 bg-red-500">
-              <div className="flex flex-row items-center gap-6 justify-between w-full">
-                  <h2 className="text-md font-bold">Modem Processing Error</h2>
-                  <p className="text-sm font-bold">
-                    SMS_Tool failed to acquire token. Likely 'Bus Error'. The system will attempt to recover automatically. If the issue persists, please logout and log back in.
-                  </p>
-              </div>
-            </Card>
-          </div>
-        )}
         <div className="flex flex-row justify-between items-center">
           <div className="flex flex-row gap-2 items-center">
             <h1 className="xl:text-3xl text-base font-bold">

--- a/hooks/home-data.ts
+++ b/hooks/home-data.ts
@@ -135,7 +135,7 @@ const useHomeData = () => {
       console.log(rawData); //
       // Add type annotation for rawData
       if (rawData.some((x: {response: string}) => x.response.toLowerCase().includes("failed"))) {
-        console.error("something broke");
+        console.error("SMS tool failure detected in modem response. Attempting service restart via reset-at-bridge.sh.");
         await fetch("/cgi-bin/quecmanager/reset-at-bridge.sh")
       }
       // fetch public ip from /cgi-bin/quecmanager/home/fetch_public_ip.sh

--- a/hooks/home-data.ts
+++ b/hooks/home-data.ts
@@ -57,8 +57,8 @@ const useHomeData = () => {
         // Set fallback data with "Unknown" values
         setData({
           simCard: {
-            slot: "Not Inserted",
-            state: "Not Inserted",
+            slot: "Unknown",
+            state: "Unknown",
             provider: "Unknown",
             phoneNumber: "Unknown",
             imsi: "-",
@@ -131,7 +131,11 @@ const useHomeData = () => {
 
       const rawData = await response.json();
       console.log(rawData); //
-
+      // Add type annotation for rawData
+      if (rawData.some((x: {response: string}) => x.response.toLowerCase().includes("failed"))) {
+        console.error("something broke");
+        await fetch("/cgi-bin/quecmanager/reset-at-bridge.sh")
+      }
       // fetch public ip from /cgi-bin/quecmanager/home/fetch_public_ip.sh
       const publicIPResponse = await fetch(
         "/cgi-bin/quecmanager/home/fetch_public_ip.sh"
@@ -141,7 +145,7 @@ const useHomeData = () => {
       const processedData: HomeData = {
         simCard: {
           slot: parseField(rawData[0].response, 1, 1, 0),
-          state: rawData[6].response.includes("READY") ? "Inserted" : "Not Inserted",
+          state: rawData[6].response.includes("READY") ? "Inserted" : rawData[6].response.includes("PIN") ? "Waiting for PIN" : rawData[6].response.includes("PUK") ? "Waiting for Password" : rawData[6].response.toLowerCase().includes("failed") ? "SMS-Tool Failed Token" : "Unknown",
           provider: parseField(rawData[2].response, 1, 1, 2),
           phoneNumber: parseField(rawData[1].response, 1, 1, 1),
           imsi: parseField(rawData[3].response, 1, 0, 0),
@@ -167,7 +171,7 @@ const useHomeData = () => {
           // The TAC and CellID are providing a data map for the network type to correlate to which index to use for the parsing
           cellId: extractValueByNetworkType(rawData[10]?.response, getNetworkType(rawData[13]?.response), { "NR5G-SA": 1, "NR5G-NSA": 2, "LTE": 1 }, { "NR5G-SA": 6, "NR5G-NSA": 4, "LTE": 6 }, false),
           trackingAreaCode: extractValueByNetworkType(rawData[10]?.response, getNetworkType(rawData[13]?.response), { "NR5G-SA": 1, "NR5G-NSA": 2, "LTE": 1 }, { "NR5G-SA": 8, "NR5G-NSA": 10, "LTE": 12 }, false),
-          cellIdRaw: extractValueByNetworkType(rawData[10]?.response, getNetworkType(rawData[13]?.response), { "NR5G-SA": 1, "NR5G-NSA": 2, "LTE": 1 }, { "NR5G-SA": 6, "NR5G-NSA": 4, "LTE": 6 }, true), 
+          cellIdRaw: extractValueByNetworkType(rawData[10]?.response, getNetworkType(rawData[13]?.response), { "NR5G-SA": 1, "NR5G-NSA": 2, "LTE": 1 }, { "NR5G-SA": 6, "NR5G-NSA": 4, "LTE": 6 }, true),
           trackingAreaCodeRaw: extractValueByNetworkType(rawData[10]?.response, getNetworkType(rawData[13]?.response), { "NR5G-SA": 1, "NR5G-NSA": 2, "LTE": 1 }, { "NR5G-SA": 8, "NR5G-NSA": 10, "LTE": 12 }, true),
           physicalCellId: getCurrentBandsPCI(rawData[13].response, getNetworkType(rawData[13].response)).join(", ") || "Unknown",
           earfcn: getCurrentBandsEARFCN(rawData[13].response).join(", "),

--- a/scripts/cgi-bin/quecmanager/reset-at-bridge.sh
+++ b/scripts/cgi-bin/quecmanager/reset-at-bridge.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+echo "Content-Type: application/json"
+echo "Cache-Control: no-cache, no-store, must-revalidate"
+echo "Pragma: no-cache"
+echo "Expires: 0"
+echo ""
+
+service socat-at-bridge restart &>/dev/null
+SOCAT_RESET_STATUS=$?
+
+# Basic response indicating the server is up
+echo "{\"status\": \"$SOCAT_RESET_STATUS\"}"

--- a/scripts/cgi-bin/quecmanager/reset-at-bridge.sh
+++ b/scripts/cgi-bin/quecmanager/reset-at-bridge.sh
@@ -1,13 +1,25 @@
 #!/bin/sh
 
+DEBUG_LOG="/tmp/socat-at-bridge-reset.log"
+
 echo "Content-Type: application/json"
 echo "Cache-Control: no-cache, no-store, must-revalidate"
 echo "Pragma: no-cache"
 echo "Expires: 0"
 echo ""
 
+
+
 service socat-at-bridge restart &>/dev/null
 SOCAT_RESET_STATUS=$?
+
+touch $DEBUG_LOG
+# Log the reset status
+if [ $SOCAT_RESET_STATUS -eq 0 ]; then
+    echo "$(date) - socat-at-bridge service restarted successfully." >> $DEBUG_LOG
+else
+    echo "$(date) - Failed to restart socat-at-bridge service. Status: $SOCAT_RESET_STATUS" >> $DEBUG_LOG
+fi
 
 # Basic response indicating the server is up
 echo "{\"status\": \"$SOCAT_RESET_STATUS\"}"

--- a/types/types.ts
+++ b/types/types.ts
@@ -2,7 +2,7 @@
 
 export interface SimCardData {
   slot: string;
-  state: "Inserted" | "Not Inserted";
+  state: "Inserted" | "Not Inserted" | "Unknown" | "Waiting for Password" | "Waiting for PIN" | "SMS-Tool Failed Token";
   provider: string;
   phoneNumber: string;
   imsi: string;


### PR DESCRIPTION
Adding in logic to address when socat-at-bridge collapses resulting sms_tool to respond with Bus error.
Adding in logic to reset socat-at-bridge service to rebuild the smd11 at bridge