### PR TITLE
[BUG FIX] Resolved auth token not getting called

### DIFF
--- a/scripts/cgi-bin/quecmanager/at_cmd/at_queue_client.sh
+++ b/scripts/cgi-bin/quecmanager/at_cmd/at_queue_client.sh
@@ -4,7 +4,8 @@
 
 QUEUE_DIR="/tmp/at_queue"
 RESULTS_DIR="$QUEUE_DIR/results"
-QUEUE_MANAGER="/www/cgi-bin/services/at_queue_manager.sh"
+HOST_DIR=$(pwd)
+QUEUE_MANAGER="${HOST_DIR}/cgi-bin/services/at_queue_manager.sh"
 POLL_INTERVAL=0.01
 
 usage() {
@@ -190,7 +191,7 @@ if [ "${SCRIPT_NAME}" != "" ]; then
         output_json "{\"error\":\"Unauthorized\"}" "0"
         exit 1
     fi
-    AUTH_RESPONSE=$(/bin/ash ../auth-token.sh process "${HTTP_AUTHORIZATION}")   
+    AUTH_RESPONSE=$(/bin/sh ${HOST_DIR}/cgi-bin/quecmanager/auth-token.sh process "${HTTP_AUTHORIZATION}")
     AUTH_RESPONSE_STATUS=$?
     if [ $AUTH_RESPONSE_STATUS -ne 0 ]; then
         output_json $AUTH_RESPONSE "0"

--- a/scripts/cgi-bin/quecmanager/at_cmd/at_queue_client.sh
+++ b/scripts/cgi-bin/quecmanager/at_cmd/at_queue_client.sh
@@ -27,13 +27,13 @@ output_json() {
 urldecode() {
     local encoded="$1"
     logger -t at_queue -p daemon.debug "urldecode: input='$encoded'"
-    
+
     # Handle %2B -> + and %22 -> " conversions
     local decoded="${encoded//%2B/+}"
     decoded="${decoded//%22/\"}"
     # Then handle other encoded characters
     decoded=$(printf '%b' "${decoded//%/\\x}")
-    
+
     logger -t at_queue -p daemon.debug "urldecode: output='$decoded'"
     echo "$decoded"
 }
@@ -42,28 +42,28 @@ urldecode() {
 get_command_id() {
     local response="$1"
     echo "DEBUG: Raw response: '$response'" >&2
-    
+
     # Strip any headers from response
     local json_response=$(echo "$response" | sed -n '/^{/,$p')
     echo "DEBUG: JSON portion: '$json_response'" >&2
-    
+
     # Try to extract command_id using grep and sed instead of jsonfilter
     local cmd_id=$(echo "$json_response" | grep -o '"command_id":"[^"]*"' | sed 's/"command_id":"//;s/"$//')
-    
+
     if [ -n "$cmd_id" ]; then
         echo "$cmd_id"
         return 0
     fi
-    
+
     # Fallback to jsonfilter if available
     echo "DEBUG: Trying jsonfilter as fallback" >&2
     local cmd_id_jsonfilter=$(echo "$json_response" | jsonfilter -e '@.command_id' 2>/dev/null)
-    
+
     if [ -n "$cmd_id_jsonfilter" ]; then
         echo "$cmd_id_jsonfilter"
         return 0
     fi
-    
+
     echo "ERROR: Failed to extract command ID from response" >&2
     return 1
 }
@@ -72,19 +72,19 @@ get_command_id() {
 normalize_at_command() {
     local cmd="$1"
     logger -t at_queue -p daemon.debug "normalize: input='$cmd'"
-    
+
     # URL decode the command
     cmd=$(urldecode "$cmd")
     logger -t at_queue -p daemon.debug "normalize: after urldecode='$cmd'"
-    
+
     # Remove any carriage returns or newlines
     cmd=$(echo "$cmd" | tr -d '\r\n')
     logger -t at_queue -p daemon.debug "normalize: after cleanup='$cmd'"
-    
+
     # Trim leading/trailing whitespace while preserving quotes
     cmd=$(echo "$cmd" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
     logger -t at_queue -p daemon.debug "normalize: final output='$cmd'"
-    
+
     echo "$cmd"
 }
 
@@ -92,12 +92,12 @@ normalize_at_command() {
 submit_command() {
     local cmd="$1"
     local priority=10
-    
+
     # Set high priority for QSCAN commands for faster processing
     if echo "$cmd" | grep -qi "AT+QSCAN"; then
         priority=1
     fi
-    
+
     # Submit using appropriate method
     if [ "${SCRIPT_NAME}" != "" ]; then
         # CGI mode - direct execution
@@ -113,7 +113,7 @@ submit_command() {
 check_result() {
     local cmd_id="$1"
     local show_headers="${2:-1}"  # Add parameter for header control
-    
+
     if [ -f "$RESULTS_DIR/$cmd_id.json" ]; then
         local result_content=$(cat "$RESULTS_DIR/$cmd_id.json")
         if [ -z "$result_content" ]; then
@@ -136,37 +136,37 @@ wait_for_completion() {
     local timeout="$2"
     local show_headers="${3:-1}"
     local result_file="$RESULTS_DIR/$cmd_id.json"
-    
+
     if [ -z "$cmd_id" ]; then
         local error_json="{\"error\":\"Invalid command ID\"}"
         output_json "$error_json" "$show_headers"
         return 1
     fi
-    
+
     # First quick check
     if [ -f "$result_file" ]; then
         output_json "$(cat "$result_file")" "$show_headers"
         return 0
     fi
-    
+
     # Wait with shorter polling interval
     local start_time=$(date +%s)
     local current_time
-    
+
     while true; do
         if [ -f "$result_file" ]; then
             output_json "$(cat "$result_file")" "$show_headers"
             return 0
         fi
-        
+
         current_time=$(date +%s)
         if [ $((current_time - start_time)) -ge "$timeout" ]; then
             break
         fi
-        
+
         sleep $POLL_INTERVAL
     done
-    
+
     local error_json=$(cat << EOF
 {
     "error": "Timeout waiting for completion",

--- a/scripts/cgi-bin/quecmanager/auth.sh
+++ b/scripts/cgi-bin/quecmanager/auth.sh
@@ -11,6 +11,7 @@ read -r POST_DATA
 USER="root"
 INPUT_PASSWORD=$(echo "$POST_DATA" | grep -o 'password=[^&]*' | cut -d= -f2-)
 RESPONSE=""
+HOST_DIR=$(pwd)
 
 # URL-decode the password while preserving most special characters
 # First decode percent-encoded sequences
@@ -53,9 +54,9 @@ GENERATED_HASH=$(printf '%s' "$INPUT_PASSWORD" | openssl passwd -1 -salt "$SALT"
 SUPPLIED_TOKEN="${HTTP_AUTHORIZATION}"
 # Compare the generated hash with the one in the shadow file
 if [ "$GENERATED_HASH" = "$USER_HASH" ]; then
-    RESPONSE=$(./auth-token.sh process "$SUPPLIED_TOKEN")
+    RESPONSE=$(/bin/sh ${HOST_DIR}/cgi-bin/quecmanager/auth-token.sh process "$SUPPLIED_TOKEN")
 else
-    RESPONSE=$(./auth-token.sh removeToken "$SUPPLIED_TOKEN")
+    RESPONSE=$(/bin/sh ${HOST_DIR}/cgi-bin/quecmanager/auth-token.sh removeToken "$SUPPLIED_TOKEN")
 fi
 
 echo "$RESPONSE"

--- a/scripts/cgi-bin/quecmanager/logout.sh
+++ b/scripts/cgi-bin/quecmanager/logout.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
 # Remove token from file
-AUTH_RESPONSE=$(./auth-token.sh removeToken "${HTTP_AUTHORIZATION}")
+HOST_DIR=$(pwd)
+AUTH_RESPONSE=$(/bin/sh ${HOST_DIR}/cgi-bin/quecmanager/auth-token.sh removeToken "${HTTP_AUTHORIZATION}")
 EXIT_CODE=$?
 
 echo "Content-Type: application/json"

--- a/scripts/cgi-bin/quecmanager/settings/change-password.sh
+++ b/scripts/cgi-bin/quecmanager/settings/change-password.sh
@@ -9,8 +9,9 @@ read -r POST_DATA
 
 # Debug log for generated hash
 DEBUG_LOG="/tmp/password_change.log"
+HOST_DIR=$(pwd)
 
-AUTH_RESPONSE=$(../auth-token.sh process "$HTTP_AUTHORIZATION")
+AUTH_RESPONSE=$(/bin/sh ${HOST_DIR}/cgi-bin/quecmanager/auth-token.sh process "$HTTP_AUTHORIZATION")
 AUTH_RESPONSE_STATUS=$?
 if [ $AUTH_RESPONSE_STATUS -ne 0 ]; then
     echo $AUTH_RESPONSE


### PR DESCRIPTION
Resolved auth-token calls not being resolved utillizing absolute pathing, relative pathing was referencing webroot; for SDXPINN this is /www so cgi-bin was attempting to call from `/www/` `./auth-token.sh` when executing the various scripts from QM resulting in a blank response.