### PR TITLE
Fix crash when AT command responses have unexpected format in device info hook

### DIFF
--- a/hooks/about-data.ts
+++ b/hooks/about-data.ts
@@ -60,6 +60,31 @@ const useAboutData = () => {
     ``;
   }, []);
 
+  // Helper function to safely parse response data
+  const safeParse = (rawResponse: string, splitPattern: string[], fallback: string = "N/A"): string => {
+    try {
+      let result = rawResponse;
+      for (const pattern of splitPattern) {
+        if (pattern.startsWith("split|")) {
+          const [, delimiter, index] = pattern.split("|");
+          const parts = result.split(delimiter);
+          if (parseInt(index) >= parts.length) return fallback;
+          result = parts[parseInt(index)];
+        } else if (pattern === "trim") {
+          result = result.trim();
+        } else if (pattern === "removeQuotes") {
+          result = result.replace(/"/g, "");
+        } else if (pattern.startsWith("replace|")) {
+          const [, from, to] = pattern.split("|");
+          result = result.replace(new RegExp(from, "g"), to);
+        }
+      }
+      return result || fallback;
+    } catch {
+      return fallback;
+    }
+  };
+
   const fetchAboutData = useCallback(async () => {
     try {
       setIsLoading(true);
@@ -78,60 +103,27 @@ const useAboutData = () => {
       // console.log("Raw data:", rawData);
 
       const processedData: AboutData = {
-        manufacturer: rawData[0].response.split("\n")[1].trim(),
-        model: rawData[1].response.split("\n")[1].trim(),
-        firmwareVersion: rawData[2].response.split("\n")[1].trim(),
-        phoneNum: rawData[3].response
-          .split("\n")[1]
-          .split(":")[1]
-          .split(",")[1]
-          .replace(/"/g, "")
-          .trim(),
-        imsi: rawData[4].response.split("\n")[1].trim(),
-        iccid: rawData[5].response.split("\n")[1].split(":")[1].trim(),
-        imei: rawData[6].response.split("\n")[1].trim(),
-        currentDeviceIP: rawData[7].response
-          .split("\n")[1]
-          .split(",")[1]
-          .replace(/"/g, "")
-          .trim(),
-        lanGateway: rawData[7].response
-          .split("\n")[1]
-          .split(":")[1]
-          .split(",")[3]
-          .replace(/"/g, "")
-          .trim(),
-        wwanIPv4: rawData[8].response
-          .split("\n")[1]
-          .split(":")[1]
-          .split(",")[4]
-          .replace(/"/g, "")
-          .trim(),
-        wwanIPv6: rawData[8].response
-          .split("\n")[2]
-          .split(",")[4]
-          .replace(/"/g, "")
-          .trim(),
-        lteCategory: rawData[9].response.split("\n")[5].split(":")[2].trim(),
-        deviceUptime: uptimeData.uptime.formatted || "N/A",
+        manufacturer: safeParse(rawData[0]?.response || "", ["split|\n|1", "trim"]),
+        model: safeParse(rawData[1]?.response || "", ["split|\n|1", "trim"]),
+        firmwareVersion: safeParse(rawData[2]?.response || "", ["split|\n|1", "trim"]),
+        phoneNum: safeParse(rawData[3]?.response || "", ["split|\n|1", "split|:|1", "split|,|1", "removeQuotes", "trim"]),
+        imsi: safeParse(rawData[4]?.response || "", ["split|\n|1", "trim"]),
+        iccid: safeParse(rawData[5]?.response || "", ["split|\n|1", "split|:|1", "trim"]),
+        imei: safeParse(rawData[6]?.response || "", ["split|\n|1", "trim"]),
+        currentDeviceIP: safeParse(rawData[7]?.response || "", ["split|\n|1", "split|,|1", "removeQuotes", "trim"]),
+        lanGateway: safeParse(rawData[7]?.response || "", ["split|\n|1", "split|:|1", "split|,|3", "removeQuotes", "trim"]),
+        wwanIPv4: safeParse(rawData[8]?.response || "", ["split|\n|1", "split|:|1", "split|,|4", "removeQuotes", "trim"]),
+        wwanIPv6: safeParse(rawData[8]?.response || "", ["split|\n|2", "split|,|4", "removeQuotes", "trim"]),
+        lteCategory: safeParse(rawData[9]?.response || "", ["split|\n|5", "split|:|2", "trim"]),
+        deviceUptime: uptimeData.uptime?.formatted || "N/A",
         // > AT+QNWCFG="3gpp_rel"
         // AT+QNWCFG="3gpp_rel"
         // +QNWCFG: "3gpp_rel",R17,R17
 
         // OK
         //
-        LTE3GppRel: rawData[10].response
-          .split("\n")[1]
-          .split(":")[1]
-          .split(",")[1]
-          .replace(/R/g, "")
-          .trim(),
-        NR3GppRel: rawData[10].response
-          .split("\n")[1]
-          .split(":")[1]
-          .split(",")[2]
-          .replace(/R/g, "")
-          .trim(),
+        LTE3GppRel: safeParse(rawData[10]?.response || "", ["split|\n|1", "split|:|1", "split|,|1", "replace|R|", "trim"]),
+        NR3GppRel: safeParse(rawData[10]?.response || "", ["split|\n|1", "split|:|1", "split|,|2", "replace|R|", "trim"])
       };
 
       setData(processedData);


### PR DESCRIPTION
# 🐛 Fix crash when AT command responses have unexpected format in device info hook

## Problem
The `useAboutData` hook was vulnerable to runtime crashes when AT command responses didn't match the expected string format. Direct string splitting operations like `.split("\n")[1]` would throw errors if:
- Response had fewer lines than expected
- Missing colons or commas in structured data
- Array indices were out of bounds
- Response was empty or malformed

This caused the entire About page to crash when device responses were incomplete or in unexpected formats.

## Solution
Implemented robust error handling with a `safeParse` helper function that:

### Safe Parsing Logic
- **Graceful fallback**: Returns "N/A" instead of crashing when parsing fails
- **Bounds checking**: Validates array indices before accessing them
- **Try-catch protection**: Wraps all parsing operations to prevent runtime errors
- **Null-safe operators**: Handles missing `rawData` entries with `?.` and `||`

### Parsing Operations Protected
- **Basic fields**: `manufacturer`, `model`, `firmwareVersion`, `imsi`, `imei`
- **Complex nested parsing**: `phoneNum`, `currentDeviceIP`, `lanGateway`
- **IPv4/IPv6 addresses**: `wwanIPv4`, `wwanIPv6`  
- **Network info**: `lteCategory`, `LTE3GppRel`, `NR3GppRel`
- **ICCID**: Smart colon-based parsing

### Helper Function Features
```typescript
safeParse(response, ["split|\n|1", "split|:|1", "split|,|3", "removeQuotes", "trim"])